### PR TITLE
Fixed #36986 -- Added Field.serialize_to_python/xml() and deserialize_from_python/xml() hooks.

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -7,8 +7,6 @@ basis for other serializers.
 from django.apps import apps
 from django.core.serializers import base
 from django.db import DEFAULT_DB_ALIAS, models
-from django.db.models import CompositePrimaryKey
-from django.utils.encoding import is_protected_type
 
 
 class Serializer(base.Serializer):
@@ -40,13 +38,7 @@ class Serializer(base.Serializer):
         return data
 
     def _value_from_field(self, obj, field):
-        if isinstance(field, CompositePrimaryKey):
-            return [self._value_from_field(obj, f) for f in field]
-        value = field.value_from_object(obj)
-        # Protected types (i.e., primitives like None, numbers, dates,
-        # and Decimals) are passed through as is. All other values are
-        # converted to string first.
-        return value if is_protected_type(value) else field.value_to_string(obj)
+        return field.serialize_to_python(obj, self)
 
     def handle_field(self, obj, field):
         self._current[field.name] = self._value_from_field(obj, field)
@@ -192,7 +184,7 @@ class Deserializer(base.Deserializer):
             # Handle all other fields
             else:
                 try:
-                    data[field.name] = field.to_python(field_value)
+                    data[field.name] = field.deserialize_from_python(field_value)
                 except Exception as e:
                     raise base.DeserializationError.WithData(
                         e, obj["model"], obj.get("pk"), field_value

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -183,6 +183,7 @@ class Serializer(base.Serializer):
             else:
 
                 def handle_m2m(value):
+                    self.indent(self.indent_level + 1)
                     self.xml.addQuickElement("object", attrs={"pk": str(value.pk)})
 
                 def queryset_iterator(obj, field):

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -264,7 +264,7 @@ class Deserializer(base.Deserializer):
 
         field_names = {f.name for f in Model._meta.get_fields()}
         # Deserialize each field.
-        for field_node in node.getElementsByTagName("field"):
+        for field_node in getChildElementsByTagName(node, "field"):
             # If the field is missing the name attribute, bail (are you
             # sensing a pattern here?)
             field_name = field_node.getAttribute("name")
@@ -308,7 +308,7 @@ class Deserializer(base.Deserializer):
                 else:
                     data[field.attname] = value
             else:
-                if field_node.getElementsByTagName("None"):
+                if getChildElementsByTagName(field_node, "None"):
                     value = None
                 else:
                     value = field.to_python(getInnerText(field_node).strip())
@@ -423,6 +423,29 @@ class Deserializer(base.Deserializer):
                 "<%s> node has invalid model identifier: '%s'"
                 % (node.nodeName, model_identifier)
             )
+
+
+def getChildElementsByTagName(node, tag_name):
+    """
+    Like Element.getElementsByTagName() but return only direct children.
+
+    Element.getElementsByTagName() searches all descendants (direct children,
+    children’s children, etc.). This prevents correct deserialization of
+    third-party embedded fields in places where only direct child elements
+    should be retrieved. For example:
+
+      <field name="author" type="EmbeddedModelField">
+        <object model="app.Model">
+          <field name="id" type="..."><None></None></field>
+
+    This method is used by the deserializer instead, except for related
+    fields which aren't supported by embedded fields.
+    """
+    return [
+        n
+        for n in node.childNodes
+        if n.nodeType == node.ELEMENT_NODE and n.tagName == tag_name
+    ]
 
 
 def getInnerText(node):

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -2,7 +2,6 @@
 XML serializer.
 """
 
-import json
 from contextlib import contextmanager
 from xml.dom import minidom, pulldom
 from xml.sax import handler
@@ -107,11 +106,7 @@ class Serializer(base.Serializer):
 
         # Get a "string version" of the object's data.
         if getattr(obj, field.name) is not None:
-            value = field.value_to_string(obj)
-            if field.get_internal_type() == "JSONField":
-                # Dump value since JSONField.value_to_string() doesn't output
-                # strings.
-                value = json.dumps(value, cls=field.encoder)
+            value = field.serialize_to_xml(obj, self)
             try:
                 self.xml.characters(value)
             except UnserializableContentError:
@@ -311,10 +306,7 @@ class Deserializer(base.Deserializer):
                 if getChildElementsByTagName(field_node, "None"):
                     value = None
                 else:
-                    value = field.to_python(getInnerText(field_node).strip())
-                    # Load value since JSONField.to_python() outputs strings.
-                    if field.get_internal_type() == "JSONField":
-                        value = json.loads(value, cls=field.decoder)
+                    value = field.deserialize_from_xml(field_node)
                 data[field.name] = value
 
         obj = base.build_instance(Model, data, self.db)

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -48,6 +48,7 @@ class Serializer(base.Serializer):
         """
         Start serialization -- open the XML document and the root element.
         """
+        self.indent_level = 0
         self.xml = SimplerXMLGenerator(
             self.stream, self.options.get("encoding", settings.DEFAULT_CHARSET)
         )
@@ -58,7 +59,7 @@ class Serializer(base.Serializer):
         """
         End serialization -- end the document.
         """
-        self.indent(0)
+        self.indent(self.indent_level)
         self.xml.endElement("django-objects")
         self.xml.endDocument()
 
@@ -71,7 +72,8 @@ class Serializer(base.Serializer):
                 "Non-model object (%s) encountered during serialization" % type(obj)
             )
 
-        self.indent(1)
+        self.indent_level += 1
+        self.indent(self.indent_level)
         attrs = {"model": str(obj._meta)}
         if not self.use_natural_primary_keys or not hasattr(obj, "natural_key"):
             obj_pk = obj.pk
@@ -84,15 +86,17 @@ class Serializer(base.Serializer):
         """
         Called after handling all fields for an object.
         """
-        self.indent(1)
+        self.indent(self.indent_level)
         self.xml.endElement("object")
+        self.indent_level -= 1
 
     def handle_field(self, obj, field):
         """
         Handle each field on an object (except for ForeignKeys and
         ManyToManyFields).
         """
-        self.indent(2)
+        self.indent_level += 1
+        self.indent(self.indent_level)
         self.xml.startElement(
             "field",
             {
@@ -119,6 +123,7 @@ class Serializer(base.Serializer):
             self.xml.addQuickElement("None")
 
         self.xml.endElement("field")
+        self.indent_level -= 1
 
     def handle_fk_field(self, obj, field):
         """
@@ -144,6 +149,7 @@ class Serializer(base.Serializer):
         else:
             self.xml.addQuickElement("None")
         self.xml.endElement("field")
+        self.indent_level -= 1
 
     def handle_m2m_field(self, obj, field):
         """
@@ -192,10 +198,12 @@ class Serializer(base.Serializer):
                 handle_m2m(relobj)
 
             self.xml.endElement("field")
+            self.indent_level -= 1
 
     def _start_relational_field(self, field):
         """Output the <field> element for relational fields."""
-        self.indent(2)
+        self.indent_level += 1
+        self.indent(self.indent_level)
         self.xml.startElement(
             "field",
             {

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -31,6 +31,7 @@ from django.utils.dateparse import (
     parse_time,
 )
 from django.utils.duration import duration_microseconds, duration_string
+from django.utils.encoding import is_protected_type
 from django.utils.functional import Promise, cached_property
 from django.utils.ipv6 import MAX_IPV6_ADDRESS_LENGTH, clean_ipv6_address
 from django.utils.text import capfirst
@@ -762,6 +763,25 @@ class Field(RegisterLookupMixin):
         Return the converted value. Subclasses should override this.
         """
         return value
+
+    def serialize_to_python(self, obj, serializer):
+        value = self.value_from_object(obj)
+        # Protected types (i.e., primitives like None, numbers, dates, and
+        # Decimals) are passed through as is. All other values are converted to
+        # string first.
+        return value if is_protected_type(value) else self.value_to_string(obj)
+
+    def deserialize_from_python(self, value):
+        return self.to_python(value)
+
+    def serialize_to_xml(self, obj, serializer, *, indent=None):
+        return self.value_to_string(obj)
+
+    def deserialize_from_xml(self, field_node):
+        from django.core.serializers.xml_serializer import getInnerText
+
+        value = getInnerText(field_node).strip()
+        return self.to_python(value)
 
     @cached_property
     def error_messages(self):

--- a/django/db/models/fields/composite.py
+++ b/django/db/models/fields/composite.py
@@ -155,6 +155,9 @@ class CompositePrimaryKey(Field):
             ]
         return value
 
+    def serialize_to_python(self, serializer, obj):
+        return [serializer._value_from_field(obj, f) for f in self]
+
 
 CompositePrimaryKey.register_lookup(TupleExact)
 CompositePrimaryKey.register_lookup(TupleGreaterThan)

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -123,6 +123,17 @@ class JSONField(CheckFieldDefaultMixin, Field):
             return transform
         return KeyTransformFactory(name)
 
+    def deserialize_from_xml(self, value):
+        value = super().deserialize_from_xml(value)
+        # Load value since JSONField.to_python() isn't defined to convert
+        # strings to Python values.
+        return json.loads(value, cls=self.decoder)
+
+    def serialize_to_xml(self, serializer, obj, *, indent=None):
+        value = super().serialize_to_xml(serializer, obj)
+        # Dump value since value_to_string() doesn't output strings.
+        return json.dumps(value, cls=self.encoder)
+
     def validate(self, value, model_instance):
         super().validate(value, model_instance)
         try:

--- a/tests/serializers/test_xml.py
+++ b/tests/serializers/test_xml.py
@@ -24,7 +24,9 @@ class XmlSerializerTestCase(SerializersTestBase, TestCase):
     <field name="author" rel="ManyToOneRel" to="serializers.author">%(author_pk)s</field>
     <field name="headline" type="CharField">Poker has no place on ESPN</field>
     <field name="pub_date" type="DateTimeField">2006-06-16T11:00:00</field>
-    <field name="categories" rel="ManyToManyRel" to="serializers.category"><object pk="%(first_category_pk)s"></object><object pk="%(second_category_pk)s"></object></field>
+    <field name="categories" rel="ManyToManyRel" to="serializers.category">
+      <object pk="%(first_category_pk)s"></object>
+      <object pk="%(second_category_pk)s"></object></field>
     <field name="meta_data" rel="ManyToManyRel" to="serializers.categorymetadata"></field>
     <field name="topics" rel="ManyToManyRel" to="serializers.topic"></field>
   </object>


### PR DESCRIPTION
This is a sketch of changes needed to the built-in serializers to support embedded model fields.

The changes aren't intended to be merged to this Django fork, rather the goal is to [add these hooks upstream in Django](https://code.djangoproject.com/ticket/36986) so that we don't need to fork the serializers.

Upstream PRs:
- https://github.com/django/django/pull/21054
- https://github.com/django/django/pull/21056
- https://github.com/django/django/pull/21057
- https://github.com/django/django/pull/21063